### PR TITLE
Fix address already in use

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,6 +64,7 @@ RUN echo "Downloading SEPIA-Home (custom bundle) ..." && \
 #
 #	Set up Nginx (HTTP)
 	sudo cp nginx/sites-available/sepia-fw-http.conf /etc/nginx/sites-enabled/sepia-fw-http.conf && \
+	sudo unlink /etc/nginx/sites-enabled/default && \
 #
 #	Prepare automatic-setup and user1
 	cd automatic-setup && \


### PR DESCRIPTION
Disables default Nginx site.
The default Nginx site binds to port 80 which can be already in use if the container is started with host network.